### PR TITLE
Added CSRF_TRUSTED_ORIGINS localhost

### DIFF
--- a/User_service/settings.py
+++ b/User_service/settings.py
@@ -28,7 +28,7 @@ DEBUG = True
 ALLOWED_HOSTS = ['*']
 
 CSRF_TRUSTED_ORIGINS = [
-    'http://220.69.203.87:8080',  # 요청의 출처를 여기에 추가
+    'http://220.69.203.87:8080', 'http://localhost:8080' # 요청의 출처를 여기에 추가
 ]
 
 # Application definition


### PR DESCRIPTION
## Overview
![image](https://github.com/user-attachments/assets/64f6d7c5-89bd-4258-b922-289b854a1eb4)
- 기존 CSRF_TRUSTED_ORIGIN인 220.69.203.87:8080로 제 환경에서는 접속이 불가능한것을 확인했습니다
- 접속 가능한 localhost를 CSRF_TRUSTED_ORIGIN으로 추가
- localhost:8080에서 회원가입 및 로그인이 안되는 오류 수정

## Change Log
- User_service/system.py 의 CSRF_TRUSTED_ORIGINS 에 localhost 추가

## To Reviewer
- 기존 CSRF_TRUSTED_ORIGIN인 220.69.203.87:8080로 제 환경에서는 접속이 불가능한것을 확인했습니다, 다들 접속이 되거나 localhost:8080으로 접속해도 회원가입 및 로그인이 가능한지 확인 부탁드립니다

